### PR TITLE
define-ffi-definer: move #:default-make-fail above use

### DIFF
--- a/libpython.rkt
+++ b/libpython.rkt
@@ -36,6 +36,8 @@
            [line (read-line file)])
       (string=? line "ON")))
 
+  (define (void-if-not-available id)
+    (lambda () void))
     
   (define-ffi-definer define-function (ffi-lib (and cpyimport-enabled path-to-cpython-lib))
     #:default-make-fail void-if-not-available)
@@ -44,9 +46,6 @@
   (define-ffi-definer define-c-lang (ffi-lib #f)
     #:default-make-fail void-if-not-available)
   
-  (define (void-if-not-available id)
-    (lambda () void))
-    
   
   
   (define-for-syntax (underscore stx)


### PR DESCRIPTION
Move a function definition above its use-sites.

(Defining the function below its uses raises an error in the current version of Racket (v6.90.0.23))